### PR TITLE
KWEB-613: Use SEO title if present - fallback to page title.

### DIFF
--- a/Sites-Theme-Kigo-Discovery/header.php
+++ b/Sites-Theme-Kigo-Discovery/header.php
@@ -15,7 +15,16 @@ $uhcols_right = 12 - $uhcols_left;
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="icon" type="image/png"  href="<?php echo get_theme_mod('site-favicon', ''); ?>" />
-    <title><?php echo get_theme_mod('site-company', wp_title()); ?></title>
+    <title>
+		<?php
+		$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+		if (!empty($bapi_meta_title)) {
+			echo $bapi_meta_title;
+		} else {
+			echo get_theme_mod('site-company', wp_title());
+		}
+		?>
+	</title>
     <?php wp_head() ?>
 </head>
 

--- a/instaparent/header.php
+++ b/instaparent/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme02/header.php
+++ b/instatheme02/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme04/header.php
+++ b/instatheme04/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme05/header.php
+++ b/instatheme05/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme06/header.php
+++ b/instatheme06/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme07/header.php
+++ b/instatheme07/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme08/header.php
+++ b/instatheme08/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/instatheme09/header.php
+++ b/instatheme09/header.php
@@ -12,14 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-      $custom_page_title_option = get_post_meta($post->ID, "meta-box-checkbox", true);
-if(!empty($bapi_meta_title) && !empty($custom_page_title_option)){ 
-  echo $bapi_meta_title;
-}else{
-  wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/kigo-booking-theme/header.php
+++ b/kigo-booking-theme/header.php
@@ -12,13 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-if(!empty($bapi_meta_title)){ 
-	echo $bapi_meta_title;
-}else{
-	wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/kigo-horizon-instatheme/header.php
+++ b/kigo-horizon-instatheme/header.php
@@ -12,13 +12,14 @@ This is the header code.
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes"/>
 <title>
-<?php $bapi_meta_title = get_post_meta($post->ID,'bapi_meta_title', true);
-if(!empty($bapi_meta_title)){ 
-	echo $bapi_meta_title;
-}else{
-	wp_title('');
-}
-?>
+	<?php
+	$bapi_meta_title = get_post_meta($post->ID, 'bapi_meta_title', true);
+	if (!empty($bapi_meta_title)) {
+		echo $bapi_meta_title;
+	} else {
+		wp_title('');
+	}
+	?>
 </title>
 <?php $themeUrl = wp_make_link_relative(get_template_directory_uri()); ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />


### PR DESCRIPTION
InstaSites used to have a checkbox on pages to decide if the title for the page was the `post_title` or the SEO `meta title`.  After this was removed clients lost the ability to use their SEO titles.

**Current proposed solution**: Use SEO meta title if present, fallback to page title.

**Implications**: All sites can experience page title changes.

To be discussed...